### PR TITLE
Add dashboard index to show own articles

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,6 @@
+class DashboardController < ApplicationController
+  before_action :authenticate_user!
+  def index
+    @articles = current_user.articles
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,21 @@
+<h1>Dashboard</h1>
+<div class='col-md-4'>
+  <% unless current_user.avatar.attachment.nil? %>
+    <%= image_tag current_user.avatar.variant(resize: "500x500") %>
+  <% end %>
+  <p><%= current_user.name %></p>
+  <p><%= current_user.email %></p>
+  <p><%= current_user.description %></p>
+</div>
+<div class='col-md-8'>
+  <% @articles.each do |article| %>
+    <div>
+      <h3><%= article.title %></h3>
+      <p><%= article.author.email %></p>
+      <p><%= article.created_at.strftime('%B %d, %Y') %></p>
+      <p><%= truncate(article.content, length: 150, separator: ' ') { link_to 'Continue', article } %></p>
+      <%= link_to 'Edit', edit_article_path(article) %>
+      <%= link_to 'Destroy', article, method: :delete, data: { confirm: 'Are you sure?' } %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   resources :articles do
     resources :comments, shallow: true, except: %i[index show]
   end
+  get 'dashboard/index'
 end

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe DashboardController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
The users may want to have a space to access only their own articles and
profile.

This adds a dashboard where the current user's articles and information
will be displayed.