### PR TITLE
Add `admin` role to User model

### DIFF
--- a/db/migrate/20190117230650_add_admin_to_users.rb
+++ b/db/migrate/20190117230650_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_11_172157) do
+ActiveRecord::Schema.define(version: 2019_01_17_230650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 2019_01_11_172157) do
     t.datetime "updated_at", null: false
     t.string "name", null: false
     t.text "description"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
To restrict some actions it is needed to have an admin user.

This adds the attribute admin to the existing User model to indicate
whether a user is admin or not.